### PR TITLE
Update Spark to 1.6.3

### DIFF
--- a/conf/muchos.props.example
+++ b/conf/muchos.props.example
@@ -36,13 +36,13 @@ accumulo_password = secret
 # Software versions
 hadoop_version = 2.7.3
 zookeeper_version = 3.4.9
-spark_version = 1.6.2
+spark_version = 1.6.3
 fluo_version = 1.0.0-incubating
 accumulo_version = 1.8.1
 # Software sha256 checksums
 hadoop_sha256 = d489df3808244b906eb38f4d081ba49e50c4603db03efd5e594a1e98b09259c2
 zookeeper_sha256 = e7f340412a61c7934b5143faef8d13529b29242ebfba2eba48169f4a8392f535
-spark_sha256 = f6b43333ca80629bacbbbc2e460d21064f53f50880f3f0a3f68745fdf8b3137e
+spark_sha256 = d13358a2d45e78d7c8cf22656d63e5715a5900fab33b3340df9e11ce3747e314
 fluo_sha256 = d54b7b7b470b3ebb51ec08b797137f2f1c1ddea1cd7ccab449d5f94129be1635
 accumulo_sha256 = eba3bfe823935ca7901ea7c2bd59c84a68b9381361699c7e260bbd9191f237f4
 


### PR DESCRIPTION
Some of the mirrors stopped hosting Spark 1.6.2.